### PR TITLE
add code for non-sd flashing, rework tests to work with and without SD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ set(MBED_OS
         mbed-os
         )
 
-set(MBED_OS_SRCS "")
+set(MBED_OS_SRCS "" TESTS/storage-nrf52/BasicFlashStorageTests.h)
 foreach (DIR in ${MBED_OS})
     if (DIR MATCHES "mbed-os/features")
         foreach (FEATURE in ${FEATURES})
@@ -178,13 +178,19 @@ add_library(storage
 target_include_directories(storage PUBLIC storage)
 
 add_executable(test-nrf52-basic
+        TESTS/storage-nrf52/BasicFlashStorageTests.h
+        TESTS/storage-nrf52/AdvancedFlashStorageTests.h
         TESTS/storage-nrf52/basic/BasicFlashStorageTests.cpp
-        TESTS/storage-nrf52/advanced/AdvancedFlashStorageTests.cpp)
+        TESTS/storage-nrf52/basic-nosd/BasicFlashStorageTestsNoSD.cpp
+        TESTS/storage-nrf52/advanced/AdvancedFlashStorageTests.cpp
+        TESTS/storage-nrf52/advanced-nosd/AdvancedFlashStorageTestsNoSD.cpp
+        TESTS/storage-nrf52/nosd/NoSDFlashStorageTest.cpp
+        )
 
 target_link_libraries(test-nrf52-basic mbed-os storage)
 
 add_custom_target(run-tests ALL
-        COMMAND mbed test -v -n tests-storage-nrf52* --app-config TESTS/settings.json
+        COMMAND mbed test -c -n tests-storage-nrf52* --app-config TESTS/settings.json
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_custom_target(debug-tests ALL

--- a/README.md
+++ b/README.md
@@ -30,27 +30,56 @@ mbed test -n tests-storage-nrf52*
 Current Status:
 
 ```
-+------------------+---------------+------------------------------+-------------------------------------------------------+--------+--------+--------+--------------------+
-| target           | platform_name | test suite                   | test case                                             | passed | failed | result | elapsed_time (sec) |
-+------------------+---------------+------------------------------+-------------------------------------------------------+--------+--------+--------+--------------------+
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage erase pages without SD-0         | 1      | 0      | OK     | 2.97               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage erase pages-0                    | 1      | 0      | OK     | 2.37               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage write big buffer-0               | 1      | 0      | OK     | 1.52               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage write buffer over page boarder-0 | 1      | 0      | OK     | 0.37               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage write byte above end address-0   | 1      | 0      | OK     | 0.25               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage write over the upper bound-0     | 1      | 0      | OK     | 0.18               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage write subsequent bytes-0         | 1      | 0      | OK     | 6.25               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced | Storage test storage write without SD-0               | 2      | 0      | OK     | 0.36               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write 1.5 words-0                | 1      | 0      | OK     | 0.32               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write 2 words-0                  | 1      | 0      | OK     | 0.33               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write 3 byte-0                   | 1      | 0      | OK     | 0.32               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write buffer-0                   | 1      | 0      | OK     | 0.42               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write byte-0                     | 1      | 0      | OK     | 0.32               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write existing fails-0           | 1      | 0      | OK     | 0.43               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write half word-0                | 1      | 0      | OK     | 0.32               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write non-aligned-0              | 1      | 0      | OK     | 0.33               |
-| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic    | Storage test storage write word-0                     | 1      | 0      | OK     | 0.31               |
-+------------------+---------------+------------------------------+-------------------------------------------------------+--------+--------+--------+--------------------+
++------------------+---------------+-----------------------------------+--------+--------------------+-------------+
+| target           | platform_name | test suite                        | result | elapsed_time (sec) | copy_method |
++------------------+---------------+-----------------------------------+--------+--------------------+-------------+
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | OK     | 23.73              | default     |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | OK     | 25.62              | default     |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | OK     | 21.35              | default     |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | OK     | 21.82              | default     |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-nosd          | OK     | 18.18              | default     |
++------------------+---------------+-----------------------------------+--------+--------------------+-------------+
+mbedgt: test suite results: 5 OK
+mbedgt: test case report:
++------------------+---------------+-----------------------------------+------------------------------------------------------------+--------+--------+--------+--------------------+
+| target           | platform_name | test suite                        | test case                                                  | passed | failed | result | elapsed_time (sec) |
++------------------+---------------+-----------------------------------+------------------------------------------------------------+--------+--------+--------+--------------------+
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage                                       | 2      | 0      | OK     | 0.06               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage erase pages                           | 1      | 0      | OK     | 0.65               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage write big buffer                      | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage write buffer over page boarder        | 1      | 0      | OK     | 0.09               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage write byte above end address          | 1      | 0      | OK     | 0.14               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage write over the upper bound            | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced      | Storage test storage write subsequent bytes                | 1      | 0      | OK     | 2.19               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage                                | 2      | 0      | OK     | 0.05               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage erase pages                    | 1      | 0      | OK     | 0.62               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage write big buffer               | 1      | 0      | OK     | 0.09               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage write buffer over page boarder | 1      | 0      | OK     | 0.09               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage write byte above end address   | 1      | 0      | OK     | 0.14               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage write over the upper bound     | 1      | 0      | OK     | 0.09               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-advanced-nosd | Storage [noSD] test storage write subsequent bytes         | 1      | 0      | OK     | 2.2                |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write 1.5 words                  | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write 2 words                    | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write 3 byte                     | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write buffer                     | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write byte                       | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write existing fails             | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write half word                  | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write non-aligned                | 1      | 0      | OK     | 0.06               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic         | Storage [SD] test storage write word                       | 1      | 0      | OK     | 0.06               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write 1.5 words                | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write 2 words                  | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write 3 byte                   | 1      | 0      | OK     | 0.06               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write buffer                   | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write byte                     | 1      | 0      | OK     | 0.08               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write existing fails           | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write half word                | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write non-aligned              | 1      | 0      | OK     | 0.07               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-basic-nosd    | Storage [noSD] test storage write word                     | 1      | 0      | OK     | 0.06               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-nosd          | Storage [nosd] test write page                             | 1      | 0      | OK     | 0.16               |
+| NRF52_DK-GCC_ARM | NRF52_DK      | tests-storage-nrf52-nosd          | Storage [nosd] test write simple                           | 1      | 0      | OK     | 0.08               |
++------------------+---------------+-----------------------------------+------------------------------------------------------------+--------+--------+--------+--------------------+
+mbedgt: test case results: 34 OK
 ```
 
 ## TODO

--- a/TESTS/storage-nrf52/AdvancedFlashStorageTests.h
+++ b/TESTS/storage-nrf52/AdvancedFlashStorageTests.h
@@ -1,0 +1,210 @@
+/*!
+ * @file
+ * @brief AdvancedFlashStorageTests
+ *
+ * Advanced Flash Storage Test Functions
+ *
+ * @author Matthias L. Jugel
+ * @date   2018-01-06
+ *
+ * @copyright &copy; 2018 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+#ifndef UBIRCH_MBED_NRF52_STORAGE_ADVANCEDFLASHSTORAGETESTS_H
+#define UBIRCH_MBED_NRF52_STORAGE_ADVANCEDFLASHSTORAGETESTS_H
+
+#ifndef NUM_PAGES
+#define NUM_PAGES   1
+#endif
+
+#include <utest/utest.h>
+#include <unity/unity.h>
+#include <NRF52FlashStorage.h>
+
+using namespace utest::v1;
+
+control_t TestStorage(const size_t n) {
+    NRF52FlashStorage flashStorage;
+
+    uint32_t location = (uint32_t) (0x3000 - 0x40 + 16 * n);
+    const uint8_t writeData[16] = {0xA1, 0xB2, 0xC3, 0xD4,
+                                   0xE5, 0xF6, 0x07, 0x18,
+                                   0x29, 0x3A, 0x4B, 0x5C,
+                                   0x6D, 0x7E, 0x8F, 0x90};
+    uint8_t readData[16] = {0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00};
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t) (location),
+                                                    (const unsigned char *) writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
+                             "failed to read from storage");
+
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData)/* sizeof(writeData)*/,
+                                         "data read does not match written data");
+
+    return n < 2 ? CaseRepeatAll : CaseNext;
+}
+
+void TestStorageErasePages() {
+    NRF52FlashStorage flashStorage;
+    uint32_t location = 0;
+    uint8_t writeByte = 0x5A;
+    uint8_t readByte1 = 0x00;
+    uint8_t readByte2 = 0x00;
+    uint8_t emptyData = 0xFF;
+    uint32_t randomAddr = 0;
+
+    for (int numPages = 0; numPages < NUM_PAGES; numPages++) {
+        randomAddr = (uint32_t) (random() & 0x0FFF);
+        printf(" >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n"
+                       "testing erase page = [%X],  address = [0x%X]\r\n", numPages, (location + randomAddr));
+        // first write one byte and read it to check if data is in the storage
+        TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((location + randomAddr), (const unsigned char *) (&writeByte),
+                                                        sizeof(writeByte)),
+                                 "failed to write to storage");
+        TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData((location + randomAddr),
+                                                       (unsigned char *) (&readByte1), sizeof(readByte1)),
+                                 "failed to read from storage");
+        TEST_ASSERT_EQUAL_HEX8_MESSAGE(writeByte, readByte1, "data read does not match written data");
+
+        // now erase the page and check if the page is completely empty (0xFF)
+        TEST_ASSERT_TRUE_MESSAGE(flashStorage.erasePage((uint8_t) (numPages), 1), "page not erased");
+        TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData((location + randomAddr),
+                                                       (unsigned char *) (&readByte2), sizeof(readByte1)),
+                                 "failed to read from storage");
+        TEST_ASSERT_EQUAL_HEX8_MESSAGE(emptyData, readByte2, "data read does not match written data");
+        location += 0x1000;
+    }
+}
+
+void TestStorageWriteSubsequentBytes() {
+    NRF52FlashStorage flashStorage;
+    uint32_t location = 0x00;
+    const uint8_t writeData[16] = {0xA1, 0xB2, 0xC3, 0xD4,
+                                   0xE5, 0xF6, 0x07, 0x18,
+                                   0x29, 0x3A, 0x4B, 0x5C,
+                                   0x6D, 0x7E, 0x8F, 0x90};
+    uint8_t readData[16] = {0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00};
+
+    for (int index = 0; index < 1; index++) {
+        for (uint16_t number = 1; number < 16 - index; number++) {
+
+            printf(" >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n"
+                           "testing loc = [0x%X],  index = [%u], number = [%u]\r\n", location, index, number);
+            TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t) (location + index),
+                                                            (const unsigned char *) &writeData[index], number),
+                                     "failed to write to storage");
+            TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
+                                     "failed to read from storage");
+            TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(&writeData[index], &readData[index], number/* sizeof(writeData)*/,
+                                                 "data read does not match written data");
+            location += number;
+        }
+    }
+}
+
+void TestStorageWriteAboveEndAddress() {
+    NRF52FlashStorage flashStorage;
+    uint32_t location;
+    const uint8_t writeByte = 0xEA;
+    uint8_t readByte = 0x00;
+
+    // get the end location of the storage
+    location = flashStorage.getEndAddress() - flashStorage.getStartAddress();
+
+    printf("#####\r\n start:(%X) end:(%X) loc:(%X) \r\n#####\r\n", flashStorage.getStartAddress(),
+           flashStorage.getEndAddress(), location);
+    TEST_ASSERT_TRUE_MESSAGE(!flashStorage.writeData(location, (const unsigned char *) (&writeByte), sizeof(writeByte)),
+                             "failed to not write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) (&readByte), sizeof(readByte)),
+                             "failed to read from storage");
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(writeByte, readByte, "data read does match written data");
+}
+
+/*!
+ * @note    This test fails, if only one page is reserved
+ */
+void TestStorageWriteOverPageBoarder() {
+    NRF52FlashStorage flashStorage;
+    uint32_t location = 0x1000 - 0x08;
+    const uint8_t writeData[16] = {0xA1, 0xB2, 0xC3, 0xD4,
+                                   0xE5, 0xF6, 0x07, 0x18,
+                                   0x29, 0x3A, 0x4B, 0x5C,
+                                   0x6D, 0x7E, 0x8F, 0x90};
+    uint8_t readData[16] = {0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00};
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t) (location),
+                                                    (const unsigned char *) writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
+                             "failed to read from storage");
+
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData)/* sizeof(writeData)*/,
+                                         "data read does not match written data");
+}
+
+
+void TestStorageWriteOverUpperBound() {
+    NRF52FlashStorage flashStorage;
+    uint16_t length = 0x20;
+    uint32_t location = (uint32_t) NUM_PAGES * 0x1000 - (length >> 1);
+    uint8_t writeData[length];
+    uint8_t readData[length];
+
+    for (int i = 0; i < length; i++) {
+        writeData[i] = (uint8_t) (i & 0xFF);
+    }
+    TEST_ASSERT_TRUE_MESSAGE(
+            !flashStorage.writeData((uint32_t) (location), (const unsigned char *) writeData, sizeof(writeData)),
+            "failed to recognize the upper bound of storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
+                             "failed to read from storage");
+    for (int j = 0; j < length; j++) {
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(writeData[j], readData[j],
+                                      "data was written over the upper bound");
+    }
+}
+
+/*!
+ * @note this test fails if the number of pages < 3
+ */
+void TestStorageWriteBigBuffer() {
+    NRF52FlashStorage flashStorage;
+    uint16_t length = 0x200;
+    uint32_t location = (uint32_t) 0x2000 - (length >> 1);
+    uint8_t writeData[length];
+    uint8_t readData[length];
+
+    for (int i = 0; i < length; i++) {
+        writeData[i] = (uint8_t) (i & 0xFF);
+    }
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t) (location),
+                                                    (const unsigned char *) writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData)/* sizeof(writeData)*/,
+                                         "data read does not match written data");
+}
+
+#endif //UBIRCH_MBED_NRF52_STORAGE_ADVANCEDFLASHSTORAGETESTS_H

--- a/TESTS/storage-nrf52/BasicFlashStorageTests.h
+++ b/TESTS/storage-nrf52/BasicFlashStorageTests.h
@@ -1,0 +1,175 @@
+/*!
+ * @file
+ * @brief BasicFlashStorageTests.h
+ *
+ * Basic Flash Storage Test Functions.
+ *
+ * @author Matthias L. Jugel
+ * @date   2018-01-06
+ *
+ * @copyright &copy; 2018 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+#ifndef UBIRCH_MBED_NRF52_STORAGE_BASICFLASHSTORAGETESTS_H
+#define UBIRCH_MBED_NRF52_STORAGE_BASICFLASHSTORAGETESTS_H
+
+#include <unity/unity.h>
+
+#ifndef NUM_PAGES
+#define NUM_PAGES   1
+#endif
+
+void TestStorageWriteWord() {
+    NRF52FlashStorage flashStorage;
+    const uint32_t writeData = 0xA1B2C3D4;
+    uint32_t readData = 0x000000;
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData (0x00, (const unsigned char *) &writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x00, (unsigned char *) &readData, sizeof(writeData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
+}
+
+void TestStorageWriteMultipleWords() {
+    NRF52FlashStorage flashStorage;
+    const uint8_t writeData[8] = {0xA1, 0xB2, 0xC3, 0xD4,
+                                  0xE5, 0xF6, 0x07, 0x18};
+    uint8_t readData[8] = {0x00, 0x00, 0x00, 0x00,
+                           0x00, 0x00, 0x00, 0x00};
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x81, (const unsigned char *) writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x81, (unsigned char *) readData, sizeof(writeData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData),
+                                         "data read does not match written data");
+}
+
+void TestStorageWriteSingleByte() {
+    NRF52FlashStorage flashStorage;
+    const uint8_t writeData = 0x2C;
+    uint8_t readData = 0x00;
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x13, (const unsigned char *) &writeData, 1),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x13, (unsigned char *) &readData, 1),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_MESSAGE(writeData, readData, "data read does not match written data");
+}
+
+void TestStorageWriteHalfWord() {
+    NRF52FlashStorage flashStorage;
+    const uint8_t writeData[4] = {0xA1, 0xB2, 0xC3, 0xD4};
+    const uint8_t readDataExpected[4] = {0xA1, 0xB2, 0x00, 0x00};
+    uint8_t readData[4] = {0x00, 0x00, 0x00, 0x00};
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x24, (const unsigned char *) writeData, 2),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x24, (unsigned char *) readData, 2),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(readData, readDataExpected, sizeof(readDataExpected),
+                                         "data read does not match written data");
+}
+
+void TestStorageWriteThreeBytes() {
+    NRF52FlashStorage flashStorage;
+    const uint8_t writeData[3] = {0xB4, 0xC3, 0xD1};
+    uint8_t readData[3] = {0x00, 0x00, 0x00};
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x35, (const unsigned char *) writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x35, (unsigned char *) readData, sizeof(writeData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData),
+                                         "data read does not match written data");
+}
+
+void TestStorageWriteWordAndHalfWord() {
+    NRF52FlashStorage flashStorage;
+    const uint8_t writeData[8] = {0xA1, 0xB2, 0xC3, 0xD4,
+                                  0xE5, 0xF6, 0x07, 0x18};
+    const uint8_t readDataExpected[8] = {0xA1, 0xB2, 0xC3, 0xD4,
+                                         0xE5, 0xF6, 0x00, 0x00};
+    uint8_t readData[8] = {0x00, 0x00, 0x00, 0x00,
+                           0x00, 0x00, 0x00, 0x00};
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x46, (const unsigned char *) writeData, 6),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x46, (unsigned char *) readData, 6),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(readData, readDataExpected, sizeof(readDataExpected),
+                                         "data read does not match written data");
+}
+
+void TestStorageWriteBuffer() {
+    NRF52FlashStorage flashStorage;
+    uint8_t writeData[12 * 4];
+    uint8_t readData[12 * 4];
+
+//    sd_rand_application_vector_get(writeData, sizeof(writeData));
+    memset(writeData, 0xAD, 12 * 4);
+    memset(readData, 0, sizeof(readData));
+
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x158, (const unsigned char *) writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x158, (unsigned char *) readData, sizeof(writeData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData),
+                                         "data read does not match written data");
+
+}
+
+void TestStorageWriteFailOnUsedFlash() {
+    NRF52FlashStorage flashStorage;
+
+    const uint32_t writeData = 0xA1B2C3D4;
+    const uint32_t writeData2 = 0x4D3C2B1A;
+    uint32_t readData = 0x000000;
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x64, (const unsigned char *) &writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x64, (unsigned char *) &readData, sizeof(writeData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
+
+    // try to write again, the read should then still be the original writeData value
+    TEST_ASSERT_TRUE_MESSAGE(!flashStorage.writeData(0x64, (const unsigned char *) &writeData2, sizeof(writeData2)),
+                             "write operation failed");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x64, (unsigned char *) &readData, sizeof(writeData2)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
+
+    // TODO: apparently, the 1 bits not yet zero will be zeroes by the second write
+}
+
+void TestStorageWriteNonAligned() {
+    NRF52FlashStorage flashStorage;
+    const uint32_t writeData = 0xA1B2C3D4;
+    uint32_t readData = 0x000000;
+
+    // TODO: the lib automatically aligned the address on 4 byte (address * 4)!!
+//    TEST_ASSERT_MESSAGE(false, "the lib auto-alignes, so this test is not possible!")
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x75, (const unsigned char *) &writeData, sizeof(writeData)),
+                             "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x75, (unsigned char *) &readData, sizeof(writeData)),
+                             "failed to read from storage");
+    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
+
+}
+
+#endif //UBIRCH_MBED_NRF52_STORAGE_BASICFLASHSTORAGETESTS_H

--- a/TESTS/storage-nrf52/advanced-nosd/AdvancedFlashStorageTestsNoSD.cpp
+++ b/TESTS/storage-nrf52/advanced-nosd/AdvancedFlashStorageTestsNoSD.cpp
@@ -1,0 +1,81 @@
+/*
+ * nRF52 flash storage library tests.
+ *
+ * @author Matthias L. Jugel, Waldemar Grünwald
+ * @date 2017-09-27
+ *
+ * Copyright 2017 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+
+#include "mbed.h"
+#include <nrf52_bitfields.h>
+
+#include "utest/utest.h"
+#include "greentea-client/test_env.h"
+
+#include "../AdvancedFlashStorageTests.h"
+
+using namespace utest::v1;
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) { // NOLINT
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(150, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+        Case("Storage [noSD] test storage",
+             TestStorage, greentea_failure_handler),
+        Case("Storage [noSD] test storage write subsequent bytes",
+             TestStorageWriteSubsequentBytes, greentea_failure_handler),
+        Case("Storage [noSD] test storage write byte above end address",
+             TestStorageWriteAboveEndAddress, greentea_failure_handler),
+        Case("Storage [noSD] test storage write buffer over page boarder",
+             TestStorageWriteOverPageBoarder, greentea_failure_handler),
+        Case("Storage [noSD] test storage write big buffer",
+             TestStorageWriteBigBuffer, greentea_failure_handler),
+        Case("Storage [noSD] test storage erase pages",
+             TestStorageErasePages, greentea_failure_handler),
+        Case("Storage [noSD] test storage write over the upper bound",
+             TestStorageWriteOverUpperBound, greentea_failure_handler),
+
+};
+
+int main() {
+    // set the storage address (exclude bootloader area)
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+    NRF_UICR->NRFFW[0] = 0x7A000;
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+
+    NRF52FlashStorage flashStorage;
+    static bool initialized = false;
+    if (!initialized) {
+        flashStorage.init();
+        initialized = true;
+    }
+    flashStorage.erasePage(0, NUM_PAGES);
+
+    Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+    Harness::run(specification);
+}

--- a/TESTS/storage-nrf52/advanced/AdvancedFlashStorageTests.cpp
+++ b/TESTS/storage-nrf52/advanced/AdvancedFlashStorageTests.cpp
@@ -27,12 +27,9 @@
 #include <NRF52FlashStorage.h>
 
 #include "utest/utest.h"
-#include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#ifndef NUM_PAGES
-#define NUM_PAGES   1
-#endif
+#include "../AdvancedFlashStorageTests.h"
 
 using namespace utest::v1;
 
@@ -43,249 +40,26 @@ void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext *context)
     bleEventQueue.call(Callback<void()>(&context->ble, &BLE::processEvents));
 }
 
-void continueTests(BLE::InitializationCompleteCallbackContext *params);
-
-int initSd() {
-    BLE &ble = BLE::Instance();
-    ble.onEventsToProcess(scheduleBleEventsProcessing);
-    return ble.init(continueTests);
-}
-
-int deinitSd() {
-
-    if (BLE::Instance().hasInitialized()) {
-        BLE::Instance().shutdown();
-    }
-    return 0;
-}
-
-
-//NRF52FlashStorage flashStorage;
-
-void TestStorageWriteSubsequentBytes() {
-    NRF52FlashStorage flashStorage;
-    uint32_t location = 0x00;
-    const uint8_t writeData[16] = {0xA1, 0xB2, 0xC3, 0xD4,
-                                   0xE5, 0xF6, 0x07, 0x18,
-                                   0x29, 0x3A, 0x4B, 0x5C,
-                                   0x6D, 0x7E, 0x8F, 0x90};
-    uint8_t readData[16] = {0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00};
-
-    for (int index = 0; index < 1; index++) {
-        for (uint16_t number = 1; number < 16 - index; number++) {
-
-            printf(" >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n"
-                           "testing loc = [0x%X],  index = [%u], number = [%u]\r\n", location, index, number);
-            TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t)(location + index), (const unsigned char *) &writeData[index], number),
-                                     "failed to write to storage");
-            TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
-                                     "failed to read from storage");
-            TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(&writeData[index], &readData[index], number/* sizeof(writeData)*/,
-                                                 "data read does not match written data");
-            location += number;
-        }
-    }
-}
-
-void TestStorageWriteAboveEndAddress(){
-    NRF52FlashStorage flashStorage;
-    uint32_t location;
-    const uint8_t writeByte = 0xEA;
-    uint8_t readByte = 0x00;
-
-    // get the end location of the storage
-    location = flashStorage.getEndAddress() - flashStorage.getStartAddress();
-
-    printf("#####\r\n start:(%X) end:(%X) loc:(%X) \r\n#####\r\n", flashStorage.getStartAddress(), flashStorage.getEndAddress(), location);
-    TEST_ASSERT_TRUE_MESSAGE(!flashStorage.writeData(location, (const unsigned char *)(&writeByte), sizeof(writeByte)),
-                             "failed to not write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) (&readByte), sizeof(readByte)),
-                             "failed to read from storage");
-    TEST_ASSERT_NOT_EQUAL_MESSAGE(writeByte, readByte, "data read does match written data");
-}
-
-/*!
- * @note    This test fails, if only one page is reserved
- */
-void TestStorageWriteOverPageBoarder(){
-    NRF52FlashStorage flashStorage;
-    uint32_t location = 0x1000 - 0x08;
-    const uint8_t writeData[16] = {0xA1, 0xB2, 0xC3, 0xD4,
-                                   0xE5, 0xF6, 0x07, 0x18,
-                                   0x29, 0x3A, 0x4B, 0x5C,
-                                   0x6D, 0x7E, 0x8F, 0x90};
-    uint8_t readData[16] = {0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00};
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t)(location), (const unsigned char *) writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
-                             "failed to read from storage");
-
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData)/* sizeof(writeData)*/,
-                                         "data read does not match written data");
-}
-/*!
- * @note this test fails if the number of pages < 3
- */
-void TestStorageWriteBigBuffer(){
-    NRF52FlashStorage flashStorage;
-    uint16_t length = 0x200;
-    uint32_t location = 0x2000 - (length >> 1);
-    uint8_t writeData[length];
-    uint8_t readData[length];
-
-    for (int i = 0; i < length; i++) {
-        writeData[i] =(uint8_t)(i & 0xFF);
-    }
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((uint32_t)(location), (const unsigned char *) writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData)/* sizeof(writeData)*/,
-                                         "data read does not match written data");
-}
-
-void TestStorageErasePages(){
-    NRF52FlashStorage flashStorage;
-    uint32_t location = 0;
-    uint8_t writeByte = 0x5A;
-    uint8_t readByte1 = 0x00;
-    uint8_t readByte2 = 0x00;
-    uint8_t emptyData = 0xFF;
-    uint32_t randomAddr = 0;
-
-    for (int numPages = 0; numPages < NUM_PAGES; numPages++) {
-        randomAddr = (rand() & 0x0FFF);
-        printf(" >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n"
-                       "testing erase page = [%X],  address = [0x%X]\r\n", numPages, (location + randomAddr));
-        // first write one byte and read it to check if data is in the storage
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((location + randomAddr), (const unsigned char *) (&writeByte), sizeof(writeByte)),
-                                 "failed to write to storage");
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData((location + randomAddr), (unsigned char *) (&readByte1), sizeof(readByte1)),
-                                 "failed to read from storage");
-        TEST_ASSERT_EQUAL_HEX8_MESSAGE(writeByte, readByte1, "data read does not match written data");
-
-        // now erase the page and check if the page is completely empty (0xFF)
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.erasePage((uint8_t)(numPages)), "page not erased");
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData((location + randomAddr), (unsigned char *) (&readByte2), sizeof(readByte1)),
-                                 "failed to read from storage");
-        TEST_ASSERT_EQUAL_HEX8_MESSAGE(readByte2, emptyData, "data read does not match written data");
-        location += 0x1000;
-    }
-}
-
-void TestStorageWriteOverUpperBound(){
-    NRF52FlashStorage flashStorage;
-    uint16_t length = 0x20;
-    uint32_t location = NUM_PAGES * 0x1000 - (length >> 1);
-    uint8_t writeData[length];
-    uint8_t readData[length];
-
-    for (int i = 0; i < length; i++) {
-        writeData[i] =(uint8_t)(i & 0xFF);
-    }
-    TEST_ASSERT_TRUE_MESSAGE(!flashStorage.writeData((uint32_t)(location), (const unsigned char *) writeData, sizeof(writeData)),
-                             "failed to recognize the upper bound of storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
-                             "failed to read from storage");
-    for (int j = 0; j < length; j++) {
-        TEST_ASSERT_NOT_EQUAL_MESSAGE(writeData[j], readData[j],
-                                      "data was written over the upper bound");
-    }
-}
-
-control_t TestStorageDisabledSd(const size_t n) {
-    NRF52FlashStorage flashStorage;
-
-    deinitSd();
-
-    uint32_t location = 0x3000 - 0x40 + 16 * n;
-    const uint8_t writeData[16] = {0xA1, 0xB2, 0xC3, 0xD4,
-                                   0xE5, 0xF6, 0x07, 0x18,
-                                   0x29, 0x3A, 0x4B, 0x5C,
-                                   0x6D, 0x7E, 0x8F, 0x90};
-    uint8_t readData[16] = {0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00};
-    TEST_ASSERT_TRUE_MESSAGE(
-            flashStorage.writeData((uint32_t) (location), (const unsigned char *) writeData, sizeof(writeData)),
-            "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(location, (unsigned char *) readData, sizeof(readData)),
-                             "failed to read from storage");
-
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData)/* sizeof(writeData)*/,
-                                         "data read does not match written data");
-
-    initSd();
-    return n < 2 ? CaseRepeatAll : CaseNext;
-}
-
-void TestStorageErasePagesDisabledSd() {
-    NRF52FlashStorage flashStorage;
-    uint32_t location = 0;
-    uint8_t writeByte = 0x5A;
-    uint8_t readByte1 = 0x00;
-    uint8_t readByte2 = 0x00;
-    uint8_t emptyData = 0xFF;
-    uint32_t randomAddr = 0;
-
-    deinitSd();
-
-    for (int numPages = 0; numPages < NUM_PAGES; numPages++) {
-        randomAddr = (rand() & 0x0FFF);
-        printf(" >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n"
-                       "testing erase page = [%X],  address = [0x%X]\r\n", numPages, (location + randomAddr));
-        // erase the page and check if the page is completely empty (0xFF)
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.erasePage((uint8_t) (numPages)), "page not erased");
-        // write one byte and read it to check if data is in the storage
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData((location + randomAddr), (const unsigned char *) (&writeByte),
-                                                        sizeof(writeByte)),
-                                 "failed to write to storage");
-        TEST_ASSERT_TRUE_MESSAGE(
-                flashStorage.readData((location + randomAddr), (unsigned char *) (&readByte1), sizeof(readByte1)),
-                "failed to read from storage");
-        TEST_ASSERT_EQUAL_HEX8_MESSAGE(writeByte, readByte1, "data read does not match written data");
-
-        // now erase the page and check if the page is completely empty (0xFF)
-        TEST_ASSERT_TRUE_MESSAGE(flashStorage.erasePage((uint8_t) (numPages)), "page not erased");
-        TEST_ASSERT_TRUE_MESSAGE(
-                flashStorage.readData((location + randomAddr), (unsigned char *) (&readByte2), sizeof(readByte1)),
-                "failed to read from storage");
-        TEST_ASSERT_EQUAL_HEX8_MESSAGE(readByte2, emptyData, "data read does not match written data");
-        location += 0x1000;
-    }
-
-    initSd();
-}
-
-
-
-
-utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) { // NOLINT
     greentea_case_failure_abort_handler(source, reason);
     return STATUS_CONTINUE;
 }
 
 Case cases[] = {
-        Case("Storage test storage erase pages-0", TestStorageErasePages, greentea_failure_handler),
-        Case("Storage test storage write subsequent bytes-0", TestStorageWriteSubsequentBytes,
-             greentea_failure_handler),
-        Case("Storage test storage write byte above end address-0", TestStorageWriteAboveEndAddress,
-             greentea_failure_handler),
-        Case("Storage test storage write buffer over page boarder-0", TestStorageWriteOverPageBoarder,
-             greentea_failure_handler),
-        Case("Storage test storage write big buffer-0", TestStorageWriteBigBuffer, greentea_failure_handler),
-        Case("Storage test storage write without SD-0", TestStorageDisabledSd, greentea_failure_handler),
-        Case("Storage test storage write over the upper bound-0", TestStorageWriteOverUpperBound,
-             greentea_failure_handler),
-        Case("Storage test storage erase pages without SD-0", TestStorageErasePagesDisabledSd,
-             greentea_failure_handler),
+        Case("Storage test storage",
+             TestStorage, greentea_failure_handler),
+        Case("Storage test storage write subsequent bytes",
+             TestStorageWriteSubsequentBytes, greentea_failure_handler),
+        Case("Storage test storage write byte above end address",
+             TestStorageWriteAboveEndAddress, greentea_failure_handler),
+        Case("Storage test storage write buffer over page boarder",
+             TestStorageWriteOverPageBoarder, greentea_failure_handler),
+        Case("Storage test storage write big buffer",
+             TestStorageWriteBigBuffer, greentea_failure_handler),
+        Case("Storage test storage erase pages",
+             TestStorageErasePages, greentea_failure_handler),
+        Case("Storage test storage write over the upper bound",
+             TestStorageWriteOverUpperBound, greentea_failure_handler),
 
 };
 
@@ -295,6 +69,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
 }
 
 void startTests(BLE::InitializationCompleteCallbackContext *params) {
+    (void) params;
     NRF52FlashStorage flashStorage;
     static bool initialized = false;
     if (!initialized) {
@@ -306,11 +81,6 @@ void startTests(BLE::InitializationCompleteCallbackContext *params) {
     Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
     Harness::run(specification);
 }
-
-void continueTests(BLE::InitializationCompleteCallbackContext *params) {
-    Harness::validate_callback();
-}
-
 
 int main() {
     // set the storage address (exclude bootloader area)

--- a/TESTS/storage-nrf52/basic-nosd/BasicFlashStorageTestsNoSD.cpp
+++ b/TESTS/storage-nrf52/basic-nosd/BasicFlashStorageTestsNoSD.cpp
@@ -1,0 +1,76 @@
+/*
+ * nRF52 flash storage library tests.
+ *
+ * @author Matthias L. Jugel
+ * @date 20179-27
+ *
+ * Copyright 2017 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+
+#include "mbed.h"
+#include <BLE.h>
+#include <nrf52_bitfields.h>
+#include <NRF52FlashStorage.h>
+
+#include "utest/utest.h"
+#include "greentea-client/test_env.h"
+
+#include "../BasicFlashStorageTests.h"
+
+using namespace utest::v1;
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) { //NOLINT
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(150, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+        Case("Storage [noSD] test storage write byte", TestStorageWriteSingleByte, greentea_failure_handler),
+        Case("Storage [noSD] test storage write half word", TestStorageWriteHalfWord, greentea_failure_handler),
+        Case("Storage [noSD] test storage write 3 byte", TestStorageWriteThreeBytes, greentea_failure_handler),
+        Case("Storage [noSD] test storage write word", TestStorageWriteWord, greentea_failure_handler),
+        Case("Storage [noSD] test storage write 2 words", TestStorageWriteMultipleWords, greentea_failure_handler),
+        Case("Storage [noSD] test storage write 1.5 words", TestStorageWriteWordAndHalfWord, greentea_failure_handler),
+        Case("Storage [noSD] test storage write buffer", TestStorageWriteBuffer, greentea_failure_handler),
+        Case("Storage [noSD] test storage write existing fails", TestStorageWriteFailOnUsedFlash, greentea_failure_handler),
+        Case("Storage [noSD] test storage write non-aligned", TestStorageWriteNonAligned, greentea_failure_handler),
+};
+
+int main() {
+    // set the storage address (exclude bootloader area)
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+    NRF_UICR->NRFFW[0] = 0x7A000;
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+
+    NRF52FlashStorage flashStorage;
+    static bool initialized = false;
+    if (!initialized) {
+        flashStorage.init();
+        initialized = true;
+    }
+    flashStorage.erasePage(0, NUM_PAGES);
+
+    Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+    Harness::run(specification);
+}

--- a/TESTS/storage-nrf52/basic/BasicFlashStorageTests.cpp
+++ b/TESTS/storage-nrf52/basic/BasicFlashStorageTests.cpp
@@ -2,7 +2,7 @@
  * nRF52 flash storage library tests.
  *
  * @author Matthias L. Jugel
- * @date 2017-09-27
+ * @date 20179-27
  *
  * Copyright 2017 ubirch GmbH (https://ubirch.com)
  *
@@ -27,178 +27,38 @@
 #include <NRF52FlashStorage.h>
 
 #include "utest/utest.h"
-#include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#ifndef NUM_PAGES
-#define NUM_PAGES   1
-#endif
+#include "../BasicFlashStorageTests.h"
 
 using namespace utest::v1;
 
-void TestStorageWriteWord() {
-    NRF52FlashStorage flashStorage;
-    const uint32_t writeData = 0xA1B2C3D4;
-    uint32_t readData = 0x000000;
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData (0x00, (const unsigned char *) &writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x00, (unsigned char *) &readData, sizeof(writeData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
-}
-
-void TestStorageWriteMultipleWords() {
-    NRF52FlashStorage flashStorage;
-    const uint8_t writeData[8] = {0xA1, 0xB2, 0xC3, 0xD4,
-                                  0xE5, 0xF6, 0x07, 0x18};
-    uint8_t readData[8] = {0x00, 0x00, 0x00, 0x00,
-                           0x00, 0x00, 0x00, 0x00};
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x81, (const unsigned char *) writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x81, (unsigned char *) readData, sizeof(writeData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData),
-                                         "data read does not match written data");
-}
-
-void TestStorageWriteSingleByte() {
-    NRF52FlashStorage flashStorage;
-    const uint8_t writeData = 0x2C;
-    uint8_t readData = 0x00;
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x13, (const unsigned char *) &writeData, 1),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x13, (unsigned char *) &readData, 1),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_MESSAGE(writeData, readData, "data read does not match written data");
-}
-
-void TestStorageWriteHalfWord() {
-    NRF52FlashStorage flashStorage;
-    const uint8_t writeData[4] = {0xA1, 0xB2, 0xC3, 0xD4};
-    const uint8_t readDataExpected[4] = {0xA1, 0xB2, 0x00, 0x00};
-    uint8_t readData[4] = {0x00, 0x00, 0x00, 0x00};
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x24, (const unsigned char *) writeData, 2),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x24, (unsigned char *) readData, 2),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(readData, readDataExpected, sizeof(readDataExpected),
-                                         "data read does not match written data");
-}
-
-void TestStorageWriteThreeBytes() {
-    NRF52FlashStorage flashStorage;
-    const uint8_t writeData[3] = {0xB4, 0xC3, 0xD1};
-    uint8_t readData[3] = {0x00, 0x00, 0x00};
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x35, (const unsigned char *) writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x35, (unsigned char *) readData, sizeof(writeData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData),
-                                         "data read does not match written data");
-}
-
-void TestStorageWriteWordAndHalfWord() {
-    NRF52FlashStorage flashStorage;
-    const uint8_t writeData[8] = {0xA1, 0xB2, 0xC3, 0xD4,
-                                  0xE5, 0xF6, 0x07, 0x18};
-    const uint8_t readDataExpected[8] = {0xA1, 0xB2, 0xC3, 0xD4,
-                                         0xE5, 0xF6, 0x00, 0x00};
-    uint8_t readData[8] = {0x00, 0x00, 0x00, 0x00,
-                           0x00, 0x00, 0x00, 0x00};
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x46, (const unsigned char *) writeData, 6),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x46, (unsigned char *) readData, 6),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(readData, readDataExpected, sizeof(readDataExpected),
-                                         "data read does not match written data");
-}
-
-void TestStorageWriteBuffer() {
-    NRF52FlashStorage flashStorage;
-    uint8_t writeData[12 * 4];
-    uint8_t readData[12 * 4];
-
-//    sd_rand_application_vector_get(writeData, sizeof(writeData));
-    memset(writeData, 0xAD, 12 * 4);
-    memset(readData, 0, sizeof(readData));
-
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x158, (const unsigned char *) writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x158, (unsigned char *) readData, sizeof(writeData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(writeData, readData, sizeof(writeData),
-                                         "data read does not match written data");
-
-}
-
-void TestStorageWriteFailOnUsedFlash() {
-    NRF52FlashStorage flashStorage;
-
-    const uint32_t writeData = 0xA1B2C3D4;
-    const uint32_t writeData2 = 0x4D3C2B1A;
-    uint32_t readData = 0x000000;
-
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x64, (const unsigned char *) &writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x64, (unsigned char *) &readData, sizeof(writeData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
-
-    // try to write again, the read should then still be the original writeData value
-    TEST_ASSERT_TRUE_MESSAGE(!flashStorage.writeData(0x64, (const unsigned char *) &writeData2, sizeof(writeData2)),
-                             "write operation failed");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x64, (unsigned char *) &readData, sizeof(writeData2)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
-
-    // TODO: apparently, the 1 bits not yet zero will be zeroes by the second write
-}
-
-void TestStorageWriteNonAligned() {
-    NRF52FlashStorage flashStorage;
-    const uint32_t writeData = 0xA1B2C3D4;
-    uint32_t readData = 0x000000;
-
-    // TODO: the lib automatically aligned the address on 4 byte (address * 4)!!
-//    TEST_ASSERT_MESSAGE(false, "the lib auto-alignes, so this test is not possible!")
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0x75, (const unsigned char *) &writeData, sizeof(writeData)),
-                             "failed to write to storage");
-    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0x75, (unsigned char *) &readData, sizeof(writeData)),
-                             "failed to read from storage");
-    TEST_ASSERT_EQUAL_HEX32_MESSAGE(writeData, readData, "data read does not match written data");
-
-}
-
-utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) { //NOLINT
     greentea_case_failure_abort_handler(source, reason);
     return STATUS_CONTINUE;
 }
-
-Case cases[] = {
-Case("Storage test storage write byte-0", TestStorageWriteSingleByte, greentea_failure_handler),
-Case("Storage test storage write half word-0", TestStorageWriteHalfWord, greentea_failure_handler),
-Case("Storage test storage write 3 byte-0", TestStorageWriteThreeBytes, greentea_failure_handler),
-Case("Storage test storage write word-0", TestStorageWriteWord, greentea_failure_handler),
-Case("Storage test storage write 2 words-0", TestStorageWriteMultipleWords, greentea_failure_handler),
-Case("Storage test storage write 1.5 words-0", TestStorageWriteWordAndHalfWord, greentea_failure_handler),
-Case("Storage test storage write buffer-0", TestStorageWriteBuffer, greentea_failure_handler),
-Case("Storage test storage write existing fails-0", TestStorageWriteFailOnUsedFlash, greentea_failure_handler),
-Case("Storage test storage write non-aligned-0", TestStorageWriteNonAligned, greentea_failure_handler),
-};
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
     GREENTEA_SETUP(150, "default_auto");
     return greentea_test_setup_handler(number_of_cases);
 }
 
+Case cases[] = {
+Case("Storage [SD] test storage write byte", TestStorageWriteSingleByte, greentea_failure_handler),
+Case("Storage [SD] test storage write half word", TestStorageWriteHalfWord, greentea_failure_handler),
+Case("Storage [SD] test storage write 3 byte", TestStorageWriteThreeBytes, greentea_failure_handler),
+Case("Storage [SD] test storage write word", TestStorageWriteWord, greentea_failure_handler),
+Case("Storage [SD] test storage write 2 words", TestStorageWriteMultipleWords, greentea_failure_handler),
+Case("Storage [SD] test storage write 1.5 words", TestStorageWriteWordAndHalfWord, greentea_failure_handler),
+Case("Storage [SD] test storage write buffer", TestStorageWriteBuffer, greentea_failure_handler),
+Case("Storage [SD] test storage write existing fails", TestStorageWriteFailOnUsedFlash, greentea_failure_handler),
+Case("Storage [SD] test storage write non-aligned", TestStorageWriteNonAligned, greentea_failure_handler),
+};
+
+
 void startTests(BLE::InitializationCompleteCallbackContext *params) {
+    (void) params;
+
     NRF52FlashStorage flashStorage;
     static bool initialized = false;
     if (!initialized) {

--- a/TESTS/storage-nrf52/basic/BasicFlashStorageTests.cpp
+++ b/TESTS/storage-nrf52/basic/BasicFlashStorageTests.cpp
@@ -2,7 +2,7 @@
  * nRF52 flash storage library tests.
  *
  * @author Matthias L. Jugel
- * @date 20179-27
+ * @date 2017-09-27
  *
  * Copyright 2017 ubirch GmbH (https://ubirch.com)
  *

--- a/TESTS/storage-nrf52/nosd/NoSDFlashStorageTest.cpp
+++ b/TESTS/storage-nrf52/nosd/NoSDFlashStorageTest.cpp
@@ -1,0 +1,104 @@
+/*
+ * @file NoSDFlashStorageTest.cpp
+ *
+ * Test that flash storage works with direct chip erase functions.
+ *
+ * @author Matthias L. Jugel
+ * @date 2017-09-27
+ *
+ * Copyright 2017 ubirch GmbH (https://ubirch.com)
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+
+#include "mbed.h"
+#include <nrf52_bitfields.h>
+#include <NRF52FlashStorage.h>
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#ifndef NUM_PAGES
+#define NUM_PAGES   1
+#endif
+
+using namespace utest::v1;
+
+
+void TestStorageWriteSimple() {
+    NRF52FlashStorage flashStorage;
+    flashStorage.init();
+
+    TEST_ASSERT_TRUE(flashStorage.erasePage(0, NUM_PAGES));
+
+    const uint32_t expected = 0x12345678;
+    uint32_t data = 0;
+
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(0, (unsigned char *) &expected, 4), "failed to write to storage");
+    TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(0, (unsigned char *) &data, 4), "failed to read from storage");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(expected, data, "data read does not match written data");
+}
+
+unsigned char expected[4096];
+
+void TestStorageWritePage() {
+    NRF52FlashStorage flashStorage;
+    flashStorage.init();
+
+    TEST_ASSERT_TRUE(flashStorage.erasePage(0, NUM_PAGES));
+
+    for (int i = 0; i < sizeof(expected); i++) expected[i] = static_cast<uint8_t>(random());
+    for (int i = 0; i < sizeof(expected) / 128; i++) {
+        TEST_ASSERT_TRUE_MESSAGE(flashStorage.writeData(128 * i, (unsigned char *) expected + 128 * i, 128),
+                                 "failed to write to storage");
+    }
+
+    uint8_t data[128];
+    for (int i = 0; i < sizeof(expected) / 128; i++) {
+        TEST_ASSERT_TRUE_MESSAGE(flashStorage.readData(128 * i, data, sizeof(data)),
+                                 "failed to read data from storage");
+        TEST_ASSERT_EQUAL_HEX8_ARRAY(expected + 128 * i, data, sizeof(data));
+    }
+
+}
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) { // NOLINT
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+Case cases[] = {
+        Case("Storage [nosd] test write simple", TestStorageWriteSimple, greentea_failure_handler),
+        Case("Storage [nosd] test write page", TestStorageWritePage, greentea_failure_handler),
+
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(150, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+int main() {
+    // set the storage address (exclude bootloader area)
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+    NRF_UICR->NRFFW[0] = 0x7A000;
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+
+    Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+    Harness::run(specification);
+}

--- a/storage/NRF52FlashStorage.cpp
+++ b/storage/NRF52FlashStorage.cpp
@@ -238,16 +238,18 @@ bool NRF52FlashStorage::erasePage(uint8_t page, uint8_t numPages) {
     if (softdevice_handler_isEnabled()) {
         fs_callback_flag = 1;
         ret = fs_erase(&fs_config, fs_config.p_start_addr + (PAGE_SIZE_WORDS * page), numPages);
-        if (ret != FS_SUCCESS) {
-            PRINTF("    fstorage ERASE ERROR    \r\n");
-            return false;
-        } else {
-            PRINTF("    fstorage ERASE successful    \r\n");
-        }
         while (fs_callback_flag == 1) /* do nothing */ ;
     } else {
         ret = nosd_erase_page(fs_config.p_start_addr + (PAGE_SIZE_WORDS * page), numPages);
     }
+
+    if (ret != FS_SUCCESS) {
+        PRINTF("    fstorage ERASE ERROR    \r\n");
+        return false;
+    } else {
+        PRINTF("    fstorage ERASE successful    \r\n");
+    }
+
     return ret == FS_SUCCESS;
 }
 
@@ -315,16 +317,18 @@ bool NRF52FlashStorage::writeData(uint32_t p_location, const unsigned char *buff
         fs_callback_flag = 1;
         ret = fs_store(&fs_config, (fs_config.p_start_addr + (locationReal >> 2)), buf32,
                        length32);      //Write data to memory address 0x0003F000. Check it with command: nrfjprog --memrd 0x0003F000 --n 16
-        if (ret != FS_SUCCESS) {
-            PRINTF("    fstorage WRITE ERROR    \r\n");
-            return false;
-        } else {
-            PRINTF("    fstorage WRITE successful    \r\n");
-        }
         while (fs_callback_flag == 1) /* do nothing */;
     } else {
         ret = nosd_store((uint32_t *) (fs_config.p_start_addr + (locationReal >> 2)), buf32, length32);
     }
+
+    if (ret != FS_SUCCESS) {
+        PRINTF("    fstorage WRITE ERROR    \r\n");
+        return false;
+    } else {
+        PRINTF("    fstorage WRITE successful    \r\n");
+    }
+
     return ret == FS_SUCCESS;
 }
 

--- a/storage/NRF52FlashStorage.cpp
+++ b/storage/NRF52FlashStorage.cpp
@@ -77,6 +77,8 @@ FS_REGISTER_CFG(fs_config_t fs_config) =
         };
 
 
+// adapted from an example found here:
+// https://devzone.nordicsemi.com/question/54763/sd_flash_write-implementation-without-softdevice/
 static fs_ret_t nosd_erase_page(const uint32_t *page_address, uint32_t num_pages) {
     if (page_address == NULL) {
         return FS_ERR_NULL_ARG;

--- a/storage/NRF52FlashStorage.h
+++ b/storage/NRF52FlashStorage.h
@@ -105,7 +105,7 @@ public:
      *
      * @return int 			true, if erasing succeeded, else false
      */
-    bool erasePage(uint8_t page = 0, uint8_t numPages = 1);
+    bool erasePage(uint8_t page, uint8_t numPages);
 
     /*!
      * Write data to the key storage


### PR DESCRIPTION
Please review and merge, when acceptable.

- adds non-sd flash writing
- duplicates tests for with and without SD operation